### PR TITLE
Minisat include hierarchy

### DIFF
--- a/libminisat_stubs.c
+++ b/libminisat_stubs.c
@@ -1,7 +1,7 @@
 
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
-#include <minisat2/Solver.h>
+#include <minisat/core/Solver.h>
 
 using namespace Minisat;
 


### PR DESCRIPTION
Changed includes to reflect the minisat include hierarchy, as set up in the resolution of the Debian bug #606643.
